### PR TITLE
modified: UserId search feature

### DIFF
--- a/src/pages/UserManagement/SearchForm/SearchFormInput.tsx
+++ b/src/pages/UserManagement/SearchForm/SearchFormInput.tsx
@@ -72,7 +72,6 @@ function SearchFormInput({ focusState }: Props) {
             inputValue={filterOptions.loginId}
             focusRef={inputRef}
             onKeyDown={handleSubmitByEnter}
-            onKeyPress={checkNumber}
           />
         </dd>
       </div>


### PR DESCRIPTION
전에 회원번호 검색창에 숫자 외에도 [e, E, +, -] 가 입력되는 현상을 방지하기 위해 해당 키 이벤트를 막는 checkNumber 함수를 추가했었는데, 로그인 ID 검색창에도 적용되어 있길래 수정했습니다.